### PR TITLE
[#130188061] Rebase our IAM changes against upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
-FROM concourse/buildroot:base
+FROM golang:1.6.3-alpine
 
-ADD assets/ /opt/resource/
+ENV CONCOURSE_CODE_PATH ${GOPATH}/src/github.com/concourse/s3-resource
+
+RUN apk add --update git bash \
+  && rm -rf /var/cache/apk/*
+
+ADD . /code
+
+RUN mkdir -p $(dirname ${CONCOURSE_CODE_PATH}) \
+    && ln -s /code ${CONCOURSE_CODE_PATH} \
+    && cd ${CONCOURSE_CODE_PATH} \
+    && ./scripts/build \
+    && mkdir -p /opt/resource \
+    && cp assets/check /opt/resource/check \
+    && cp assets/in /opt/resource/in \
+    && cp assets/out /opt/resource/out \
+    && cd / \
+    && rm -rf ${GOPATH} /code

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# Note: forked
+
+This resource has been forked to add support for [retrieving AWS credentials
+from IAM instance profiles][IAM]. That feature [isn't going to be
+implemented upstream][issue] at the moment, but the Concourse team are
+looking at other ways to retrieve credentials in the future.
+
+[IAM]: http://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2
+[issue]: https://github.com/concourse/s3-resource/pull/22
+
+Please do not add additional features or bug fixes to this fork/branch
+without first talking to the Tech Lead or Tech Architect on the Government
+PaaS team.
+
+[Docker Hub][hub] builds a container from the `gds` branch. There is no
+automated testing because the integration tests require credentials, so you
+will need to run the tests yourself.
+
+[hub]: https://hub.docker.com/u/governmentpaas/
+
 # S3 Resource
 
 Versions objects in an S3 bucket, by pattern-matching filenames to identify

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -19,6 +19,7 @@ func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 }
 
+var useInstanceProfile = os.Getenv("S3_USE_INSTANCE_PROFILE")
 var accessKeyID = os.Getenv("S3_TESTING_ACCESS_KEY_ID")
 var secretAccessKey = os.Getenv("S3_TESTING_SECRET_ACCESS_KEY")
 var versionedBucketName = os.Getenv("S3_VERSIONED_TESTING_BUCKET")
@@ -65,8 +66,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	inPath = sd.InPath
 	outPath = sd.OutPath
 
-	Ω(accessKeyID).ShouldNot(BeEmpty(), "must specify $S3_TESTING_ACCESS_KEY_ID")
-	Ω(secretAccessKey).ShouldNot(BeEmpty(), "must specify $S3_TESTING_SECRET_ACCESS_KEY")
+	if useInstanceProfile == "" {
+		Ω(accessKeyID).ShouldNot(BeEmpty(),
+			"must specify $S3_TESTING_ACCESS_KEY_ID or $S3_USE_INSTANCE_PROFILE=true")
+		Ω(secretAccessKey).ShouldNot(BeEmpty(),
+			"must specify $S3_TESTING_SECRET_ACCESS_KEY or $S3_USE_INSTANCE_PROFILE=true")
+	}
 	Ω(versionedBucketName).ShouldNot(BeEmpty(), "must specify $S3_VERSIONED_TESTING_BUCKET")
 	Ω(bucketName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_BUCKET")
 	Ω(regionName).ShouldNot(BeEmpty(), "must specify $S3_TESTING_REGION")

--- a/s3client.go
+++ b/s3client.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -84,7 +86,17 @@ func NewAwsConfig(
 	var creds *credentials.Credentials
 
 	if accessKey == "" && secretKey == "" {
-		creds = credentials.AnonymousCredentials
+		// Try with instance profile
+		creds := credentials.NewCredentials(
+			&ec2rolecreds.EC2RoleProvider{
+				Client: ec2metadata.New(session.New()),
+			})
+		cred_details, _ := creds.Get()
+
+		// If unsuccessful fall back to anonymous
+		if cred_details == (credentials.Value{}) {
+			creds = credentials.AnonymousCredentials
+		}
 	} else {
 		creds = credentials.NewStaticCredentials(accessKey, secretKey, "")
 	}


### PR DESCRIPTION
## What

Our fork has fallen behind upstream. As part of the release CI story, we want to be able to use `acl` param for the put action to set a public-read acl. This functionality didn't exist when we forked this.

### Concerning branches

Our fork has been using the `gds` branch as the main branch up to now. Since this fork was created, we've established a convention of using `gds_master` as the main branch for forks. I've therefore created a `gds_master` branch from upstream master, and targeted this PR against it. When this is merged, I'll update the dockerhub settings to build from `gds_master` instead of `gds`.

## Sugestions for review

* Verify that this has been rebased correctly by comparing the commits with the original branch.
* Run paas-cf with the s3-iam resource pointed at the tag `rebase_iam_changes`.

## Who can review

Anyone but @henrytk or myself.