### PR TITLE
[#154957353] Support initial version and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ One of the following two options must be specified:
   without resorting to version numbers. This property is the path to the file
   in your S3 bucket.
 
+### Initial state
+
+If no resource versions exist you can set up this resource to emit an initial version with a specified content. This won't create a real resource in S3 but only create an initial version for Concourse. The resource file will be created as usual when you `get` a resource with an initial version.
+
+You can define one of the following two options:
+
+* `initial_path`: *Optional.* Must be used with the `regexp` option. You should set this to the file path containing the initial version which would match the given regexp. E.g. if `regexp` is `file/build-(.*).zip`, then `initial_path` might be `file/build-0.0.0.zip`. The resource version will be `0.0.0` in this case.
+
+* `initial_version`: *Optional.* Must be used with the `versioned_file` option. This will be the resource version.
+
+By default the resource file will be created with no content when `get` runs. You can set the content by using one of the following options:
+
+* `initial_content_text`: *Optional.* Initial content as a string.
+
+* `initial_content_binary`: *Optional.* You can pass binary content as a base64 encoded string.
+
 ## Behavior
 
 ### `check`: Extract versions from the bucket.
@@ -105,7 +121,7 @@ Places the following files in the destination:
 
 #### Parameters
 
-* `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred.
+* `unpack`: *Optional.* If true and the file is an archive (tar, gzipped tar, other gzipped file, or zip), unpack the file. Gzipped tarballs will be both ungzipped and untarred. It is ignored when `get` is running on the initial version.
 
 
 ### `out`: Upload an object to the bucket.

--- a/check/command.go
+++ b/check/command.go
@@ -32,6 +32,13 @@ func (command *Command) Run(request Request) (Response, error) {
 func (command *Command) checkByRegex(request Request) Response {
 	extractions := versions.GetBucketFileVersions(command.s3client, request.Source)
 
+	if request.Source.InitialPath != "" {
+		extraction, ok := versions.Extract(request.Source.InitialPath, request.Source.Regexp)
+		if ok {
+			extractions = append([]versions.Extraction{extraction}, extractions...)
+		}
+	}
+
 	if len(extractions) == 0 {
 		return nil
 	}
@@ -51,6 +58,10 @@ func (command *Command) checkByVersionedFile(request Request) Response {
 
 	if err != nil {
 		s3resource.Fatal("finding versions", err)
+	}
+
+	if request.Source.InitialVersion != "" {
+		bucketVersions = append(bucketVersions, request.Source.InitialVersion)
 	}
 
 	if len(bucketVersions) == 0 {

--- a/check/command_test.go
+++ b/check/command_test.go
@@ -66,6 +66,24 @@ var _ = Describe("Check Command", func() {
 				))
 			})
 
+			Context("when the initial version is set", func() {
+				It("still returns the latest version", func() {
+					request.Version.Path = ""
+					request.Source.InitialPath = "files/abc-0.0.tgz"
+					request.Source.Regexp = "files/abc-(.*).tgz"
+
+					response, err := command.Run(request)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(response).Should(HaveLen(1))
+					Ω(response).Should(ConsistOf(
+						s3resource.Version{
+							Path: "files/abc-3.53.tgz",
+						},
+					))
+				})
+			})
+
 			Context("when the regexp does not match anything", func() {
 				It("does not explode", func() {
 					request.Source.Regexp = "no-files/missing-(.*).tgz"
@@ -73,6 +91,24 @@ var _ = Describe("Check Command", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 
 					Ω(response).Should(HaveLen(0))
+				})
+
+				Context("when the initial version is set", func() {
+					It("returns the initial version", func() {
+						request.Version.Path = ""
+						request.Source.InitialPath = "no-files/missing-0.0.tgz"
+						request.Source.Regexp = "no-files/missing-(.*).tgz"
+
+						response, err := command.Run(request)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(response).Should(HaveLen(1))
+						Ω(response).Should(ConsistOf(
+							s3resource.Version{
+								Path: "no-files/missing-0.0.tgz",
+							},
+						))
+					})
 				})
 			})
 
@@ -114,30 +150,66 @@ var _ = Describe("Check Command", func() {
 			})
 
 			Context("when using versioned file", func() {
-				BeforeEach(func() {
-					s3client.BucketFileVersionsReturns([]string{
-						"file-version-3",
-						"file-version-2",
-						"file-version-1",
-					}, nil)
+				Context("when there are existing versions", func() {
+					BeforeEach(func() {
+						s3client.BucketFileVersionsReturns([]string{
+							"file-version-3",
+							"file-version-2",
+							"file-version-1",
+						}, nil)
+					})
+
+					It("includes all versions from the previous one and the current one", func() {
+						request.Version.VersionID = "file-version-2"
+						request.Source.VersionedFile = "files/versioned-file"
+
+						response, err := command.Run(request)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(response).Should(HaveLen(2))
+						Ω(response).Should(ConsistOf(
+							s3resource.Version{
+								VersionID: "file-version-2",
+							},
+							s3resource.Version{
+								VersionID: "file-version-3",
+							},
+						))
+					})
 				})
 
-				It("includes all versions from the previous one and the current one", func() {
-					request.Version.VersionID = "file-version-2"
-					request.Source.VersionedFile = "files/(.*).tgz"
+				Context("when no version exists", func() {
+					BeforeEach(func() {
+						s3client.BucketFileVersionsReturns([]string{}, nil)
+					})
 
-					response, err := command.Run(request)
-					Ω(err).ShouldNot(HaveOccurred())
+					It("returns no versions", func() {
+						request.Version.VersionID = ""
+						request.Source.VersionedFile = "files/versioned-file"
 
-					Ω(response).Should(HaveLen(2))
-					Ω(response).Should(ConsistOf(
-						s3resource.Version{
-							VersionID: "file-version-2",
-						},
-						s3resource.Version{
-							VersionID: "file-version-3",
-						},
-					))
+						response, err := command.Run(request)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(response).Should(HaveLen(0))
+					})
+
+					Context("when the initial version is set", func() {
+						It("returns the initial version", func() {
+							request.Version.VersionID = ""
+							request.Source.VersionedFile = "files/versioned-file"
+							request.Source.InitialVersion = "file-version-0"
+
+							response, err := command.Run(request)
+							Ω(err).ShouldNot(HaveOccurred())
+
+							Ω(response).Should(HaveLen(1))
+							Ω(response).Should(ConsistOf(
+								s3resource.Version{
+									VersionID: "file-version-0",
+								},
+							))
+						})
+					})
 				})
 			})
 		})

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+docker build --target resource -f "${DOCKERFILE_PATH}" -t "${IMAGE_NAME}" .

--- a/in/command_test.go
+++ b/in/command_test.go
@@ -195,7 +195,7 @@ var _ = Describe("In Command", func() {
 				request.Source.Regexp = "not-matching-anything"
 			})
 
-			It("returns an h", func() {
+			It("returns an error", func() {
 				_, err := command.Run(destDir, request)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("regex does not match provided version"))
@@ -370,6 +370,167 @@ var _ = Describe("In Command", func() {
 					_, err := command.Run(destDir, request)
 					Expect(err).To(HaveOccurred())
 				})
+			})
+		})
+
+		Context("when the requested path is the initial path", func() {
+			var initialFilename string
+
+			BeforeEach(func() {
+				initialFilename = "a-file-0.0"
+				request.Source.InitialPath = "files/a-file-0.0"
+				request.Version.Path = request.Source.InitialPath
+				request.Source.InitialContentText = "the hard questions are hard 🙈"
+			})
+
+			It("it creates a file containing the initial text content", func() {
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				contentFile := filepath.Join(destDir, initialFilename)
+				Ω(contentFile).Should(BeARegularFile())
+				contents, err := ioutil.ReadFile(contentFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(string(contents)).Should(Equal(request.Source.InitialContentText))
+			})
+
+			Context("when the initial content is binary", func() {
+				BeforeEach(func() {
+					request.Source.InitialContentText = ""
+					request.Source.InitialContentBinary = "dGhlIGhhcmQgcXVlc3Rpb25zIGFyZSBoYXJkIPCfmYg="
+				})
+				It("it creates a file containing the initial binary content", func() {
+					_, err := command.Run(destDir, request)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					contentFile := filepath.Join(destDir, initialFilename)
+					Ω(contentFile).Should(BeARegularFile())
+					contents, err := ioutil.ReadFile(contentFile)
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(string(contents)).Should(Equal("the hard questions are hard 🙈"))
+				})
+
+				Context("when base64 decoding fails", func() {
+					BeforeEach(func() {
+						request.Source.InitialContentBinary = "not base64 data 🙈"
+					})
+					It("should return with an error", func() {
+						_, err := command.Run(destDir, request)
+						Ω(err).Should(HaveOccurred())
+					})
+				})
+			})
+
+			It("should not write the URL file", func() {
+				urlPath := filepath.Join(destDir, "url")
+				Ω(urlPath).ShouldNot(ExistOnFilesystem())
+
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(urlPath).ShouldNot(ExistOnFilesystem())
+			})
+
+			It("should not include a URL in the metadata", func() {
+				response, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				for _, metadatum := range response.Metadata {
+					Ω(metadatum.Name).ShouldNot(Equal("url"))
+				}
+			})
+
+			It("should not attempt to unpack the initial content", func() {
+				request.Params.Unpack = true
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				contentFile := filepath.Join(destDir, initialFilename)
+				Ω(contentFile).Should(BeARegularFile())
+				contents, err := ioutil.ReadFile(contentFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(string(contents)).Should(Equal(request.Source.InitialContentText))
+			})
+		})
+
+		Context("when the requested version is the initial version", func() {
+			var filename = "testfile"
+
+			BeforeEach(func() {
+				request.Source.Regexp = ""
+				request.Source.VersionedFile = "file/testfile"
+				request.Source.InitialVersion = "0.0.0"
+				request.Version.VersionID = request.Source.InitialVersion
+				request.Source.InitialContentText = "the hard questions are hard 🙈"
+			})
+
+			It("it creates a file containing the initial text content", func() {
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				contentFile := filepath.Join(destDir, filename)
+				Ω(contentFile).Should(BeARegularFile())
+				contents, err := ioutil.ReadFile(contentFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(string(contents)).Should(Equal(request.Source.InitialContentText))
+			})
+
+			Context("when the initial content is binary", func() {
+				BeforeEach(func() {
+					request.Source.InitialContentText = ""
+					request.Source.InitialContentBinary = "dGhlIGhhcmQgcXVlc3Rpb25zIGFyZSBoYXJkIPCfmYg="
+				})
+				It("it creates a file containing the initial binary content", func() {
+					_, err := command.Run(destDir, request)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					contentFile := filepath.Join(destDir, filename)
+					Ω(contentFile).Should(BeARegularFile())
+					contents, err := ioutil.ReadFile(contentFile)
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(string(contents)).Should(Equal("the hard questions are hard 🙈"))
+				})
+
+				Context("when base64 decoding fails", func() {
+					BeforeEach(func() {
+						request.Source.InitialContentBinary = "not base64 data 🙈"
+					})
+					It("should return with an error", func() {
+						_, err := command.Run(destDir, request)
+						Ω(err).Should(HaveOccurred())
+					})
+				})
+			})
+
+			It("should not write the URL file", func() {
+				urlPath := filepath.Join(destDir, "url")
+				Ω(urlPath).ShouldNot(ExistOnFilesystem())
+
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(urlPath).ShouldNot(ExistOnFilesystem())
+			})
+
+			It("should not include a URL in the metadata", func() {
+				response, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				for _, metadatum := range response.Metadata {
+					Ω(metadatum.Name).ShouldNot(Equal("url"))
+				}
+			})
+
+			It("should not attempt to unpack the initial content", func() {
+				request.Params.Unpack = true
+				_, err := command.Run(destDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				contentFile := filepath.Join(destDir, filename)
+				Ω(contentFile).Should(BeARegularFile())
+				contents, err := ioutil.ReadFile(contentFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(string(contents)).Should(Equal(request.Source.InitialContentText))
 			})
 		})
 	})

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -20,11 +20,11 @@ import (
 
 var _ = Describe("in", func() {
 	var (
-		command *exec.Cmd
-		stdin   *bytes.Buffer
-		session *gexec.Session
-		destDir string
-
+		command            *exec.Cmd
+		inRequest          in.Request
+		stdin              *bytes.Buffer
+		session            *gexec.Session
+		destDir            string
 		expectedExitStatus int
 	)
 
@@ -47,6 +47,10 @@ var _ = Describe("in", func() {
 
 	JustBeforeEach(func() {
 		var err error
+
+		err = json.NewEncoder(stdin).Encode(inRequest)
+		Ω(err).ShouldNot(HaveOccurred())
+
 		session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Ω(err).ShouldNot(HaveOccurred())
 
@@ -55,8 +59,6 @@ var _ = Describe("in", func() {
 	})
 
 	Context("with a versioned_file and a regex", func() {
-		var inRequest in.Request
-
 		BeforeEach(func() {
 			inRequest = in.Request{
 				Source: s3resource.Source{
@@ -73,9 +75,6 @@ var _ = Describe("in", func() {
 			}
 
 			expectedExitStatus = 1
-
-			err := json.NewEncoder(stdin).Encode(inRequest)
-			Ω(err).ShouldNot(HaveOccurred())
 		})
 
 		It("returns an error", func() {
@@ -84,7 +83,6 @@ var _ = Describe("in", func() {
 	})
 
 	Context("when the given version only has a path", func() {
-		var inRequest in.Request
 		var directoryPrefix string
 
 		BeforeEach(func() {
@@ -103,9 +101,6 @@ var _ = Describe("in", func() {
 					Path: filepath.Join(directoryPrefix, "some-file-2"),
 				},
 			}
-
-			err := json.NewEncoder(stdin).Encode(inRequest)
-			Ω(err).ShouldNot(HaveOccurred())
 
 			tempFile, err := ioutil.TempFile("", "file-to-upload")
 			Ω(err).ShouldNot(HaveOccurred())
@@ -168,10 +163,48 @@ var _ = Describe("in", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(urlContents).Should(Equal([]byte(buildEndpoint(bucketName, endpoint) + "/in-request-files/some-file-2")))
 		})
+
+		Context("when the path matches the initial path", func() {
+			BeforeEach(func() {
+				inRequest.Source.InitialPath = filepath.Join(directoryPrefix, "some-file-0.0.0")
+				inRequest.Source.InitialContentText = "initial content"
+				inRequest.Version.Path = inRequest.Source.InitialPath
+			})
+
+			It("uses the initial content", func() {
+				reader := bytes.NewBuffer(session.Out.Contents())
+
+				var response in.Response
+				err := json.NewDecoder(reader).Decode(&response)
+
+				Ω(response).Should(Equal(in.Response{
+					Version: s3resource.Version{
+						Path: inRequest.Source.InitialPath,
+					},
+					Metadata: []s3resource.MetadataPair{
+						{
+							Name:  "filename",
+							Value: "some-file-0.0.0",
+						},
+					},
+				}))
+
+				Ω(filepath.Join(destDir, "some-file-0.0.0")).Should(BeARegularFile())
+				contents, err := ioutil.ReadFile(filepath.Join(destDir, "some-file-0.0.0"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(contents).Should(Equal([]byte(inRequest.Source.InitialContentText)))
+
+				Ω(filepath.Join(destDir, "version")).Should(BeARegularFile())
+				versionContents, err := ioutil.ReadFile(filepath.Join(destDir, "version"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(versionContents).Should(Equal([]byte("0.0.0")))
+
+				Ω(filepath.Join(destDir, "url")).ShouldNot(BeARegularFile())
+			})
+		})
 	})
 
 	Context("when the given version has a versionID and path", func() {
-		var inRequest in.Request
 		var directoryPrefix string
 		var expectedVersion string
 
@@ -208,9 +241,6 @@ var _ = Describe("in", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			expectedVersion = versions[1]
 			inRequest.Version.VersionID = expectedVersion
-
-			err = json.NewEncoder(stdin).Encode(inRequest)
-			Ω(err).ShouldNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -260,10 +290,49 @@ var _ = Describe("in", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(urlContents).Should(Equal([]byte(buildEndpoint(versionedBucketName, endpoint) + "/in-request-files-versioned/some-file?versionId=" + expectedVersion)))
 		})
+
+		Context("when the version ID matches the InitialVersion", func() {
+			BeforeEach(func() {
+				inRequest.Source.InitialVersion = "0.0.0"
+				inRequest.Source.InitialContentText = "initial content"
+				inRequest.Version.VersionID = inRequest.Source.InitialVersion
+				expectedVersion = inRequest.Source.InitialVersion
+			})
+
+			It("uses the initial content", func() {
+				reader := bytes.NewBuffer(session.Out.Contents())
+
+				var response in.Response
+				err := json.NewDecoder(reader).Decode(&response)
+
+				Ω(response).Should(Equal(in.Response{
+					Version: s3resource.Version{
+						VersionID: inRequest.Source.InitialVersion,
+					},
+					Metadata: []s3resource.MetadataPair{
+						{
+							Name:  "filename",
+							Value: "some-file",
+						},
+					},
+				}))
+
+				Ω(filepath.Join(destDir, "some-file")).Should(BeARegularFile())
+				contents, err := ioutil.ReadFile(filepath.Join(destDir, "some-file"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(contents).Should(Equal([]byte(inRequest.Source.InitialContentText)))
+
+				Ω(filepath.Join(destDir, "version")).Should(BeARegularFile())
+				versionContents, err := ioutil.ReadFile(filepath.Join(destDir, "version"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(versionContents).Should(Equal([]byte(expectedVersion)))
+
+				Ω(filepath.Join(destDir, "url")).ShouldNot(BeARegularFile())
+			})
+		})
 	})
 
 	Context("when cloudfront_url is set", func() {
-		var inRequest in.Request
 		var directoryPrefix string
 
 		BeforeEach(func() {
@@ -301,9 +370,6 @@ var _ = Describe("in", func() {
 				_, err = s3client.UploadFile(bucketName, filepath.Join(directoryPrefix, fmt.Sprintf("some-file-%d", i)), tempFile.Name(), s3resource.NewUploadFileOptions())
 				Ω(err).ShouldNot(HaveOccurred())
 			}
-
-			err = os.Remove(tempFile.Name())
-			Ω(err).ShouldNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -349,8 +415,6 @@ var _ = Describe("in", func() {
 	})
 
 	Context("when cloudfront_url is set but has too few dots", func() {
-		var inRequest in.Request
-
 		BeforeEach(func() {
 			inRequest = in.Request{
 				Source: s3resource.Source{
@@ -368,9 +432,6 @@ var _ = Describe("in", func() {
 			}
 
 			expectedExitStatus = 1
-
-			err := json.NewEncoder(stdin).Encode(inRequest)
-			Ω(err).ShouldNot(HaveOccurred())
 		})
 
 		It("returns an error", func() {

--- a/models.go
+++ b/models.go
@@ -16,11 +16,32 @@ type Source struct {
 	SSEKMSKeyId          string `json:"sse_kms_key_id"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
 	SkipSSLVerification  bool   `json:"skip_ssl_verification"`
+	InitialVersion       string `json:"initial_version"`
+	InitialPath          string `json:"initial_path"`
+	InitialContentText   string `json:"initial_content_text"`
+	InitialContentBinary string `json:"initial_content_binary"`
 }
 
 func (source Source) IsValid() (bool, string) {
 	if source.Regexp != "" && source.VersionedFile != "" {
 		return false, "please specify either regexp or versioned_file"
+	}
+
+	if source.Regexp != "" && source.InitialVersion != "" {
+		return false, "please use initial_path when regexp is set"
+	}
+
+	if source.VersionedFile != "" && source.InitialPath != "" {
+		return false, "please use initial_version when versioned_file is set"
+	}
+
+	if source.InitialContentText != "" && source.InitialContentBinary != "" {
+		return false, "please use intial_content_text or initial_content_binary but not both"
+	}
+
+	hasInitialContent := source.InitialContentText != "" || source.InitialContentBinary != ""
+	if hasInitialContent && source.InitialVersion == "" && source.InitialPath == "" {
+		return false, "please specify initial_version or initial_path if initial content is set"
 	}
 
 	return true, ""


### PR DESCRIPTION
## What

### Initial state

If no resource versions exist you can set up this resource to emit an initial version with a specified content. This won't create a real resource in S3 but only create an initial version for Concourse. The resource file will be created as usual when you `get` a resource with an initial version.

You can define one of the following two options:

* `initial_path`: *Optional.* Must be used with the `regexp` option. You should set this to the file path containing the initial version which would match the given regexp. E.g. if `regexp` is `file/build-(.*).zip`, then `initial_path` might be `file/build-0.0.0.zip`. The resource version will be `0.0.0` in this case.

* `initial_version`: *Optional.* Must be used with the `versioned_file` option. This will be the resource version.

By default the resource file will be created with no content when `get` runs. You can set the content by using one of the following options:

* `initial_content_text`: *Optional.* Initial content as a string.

* `initial_content_binary`: *Optional.* You can pass binary content as a base64 encoded string.

## How to review

* Code review.
* Run the integration tests. For that you need to create two S3 buckets in dev: a version and an unversioned one. E.g. "${DEPLOY_ENV}-resource-test-versioned" and "${DEPLOY_ENV}-resource-test-unversioned"

```
docker build --target resource . -t s3-resource --build-arg \
  S3_TESTING_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" --build-arg \
  S3_TESTING_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" --build-arg \
  S3_TESTING_SESSION_TOKEN="${AWS_SESSION_TOKEN}" --build-arg \
  S3_TESTING_BUCKET="${DEPLOY_ENV}-s3-resource-test-unversioned" --build-arg \
  S3_VERSIONED_TESTING_BUCKET="${DEPLOY_ENV}-s3-resource-test-versioned" --build-arg \
  S3_TESTING_REGION="eu-west-1" --build-arg S3_ENDPOINT="https://s3.eu-west-1.amazonaws.com"
```

**Post-merge:** Once merged, this will be built as a container by DockerHub: https://hub.docker.com/r/governmentpaas/s3-resource/. Get the new tag from that, and update the various `[TMP]`/`[WIP]` commits in https://github.com/alphagov/paas-bootstrap/pull/157 https://github.com/alphagov/paas-release-ci/pull/60 https://github.com/alphagov/paas-cf/pull/1326 to use that revision of the container instead of the `initial_version` branch.

## Who can review

Not @46bit or me.
