### PR TITLE
Update alpine image in use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as builder
+FROM golang:1.12-alpine3.9 as builder
 COPY . /go/src/github.com/concourse/s3-resource
 ENV CGO_ENABLED 0
 RUN go build -o /assets/in github.com/concourse/s3-resource/cmd/in


### PR DESCRIPTION
The version of Apline in use has a bug in which no root password is set. This has been picked up by Cyber Security.